### PR TITLE
expose .copy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ Get the current state.
 ### `window.choo.history`
 Get an overview of the most recent events.
 
+### `window.choo.copy`
+Seralize an object into JSON and copy it to the clipboard.
+Must be called in response to a user gesture event, like click or keyup.
+
+Example:
+
+```js
+window.addEventListener('keyup', function (e) {
+  // press 'c' to copy current state
+  if (e.keyCode === 67) {
+    window.choo.copy(window.choo.state)
+  }
+})
+
+// also works with nested paths such as:
+var object = { hello: { world: { lorem: 'ipsum' } } }
+window.choo.copy('hello.world.lorem', object)
+// will copy 'ipsum' to keyboard
+```
+
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,29 @@ Must be called in response to a user gesture event, like click or keyup.
 
 Example:
 
+#### copy whole choo state to clipboard
+
 ```js
 window.addEventListener('keyup', function (e) {
-  // press 'c' to copy current state
+  // press 'c' to copy current state to clipboard
   if (e.keyCode === 67) {
     window.choo.copy()
   }
 })
+```
 
+#### copy choo state at a specific path
+
+```js
+window.addEventListener('keyup', function (e) {
+  // press 'c' to copy current state at a specific path
+  if (e.keyCode === 67) {
+    window.choo.copy('state.foo.bar')
+  }
+})
+```
+
+```js
 // also works with nested paths such as:
 var object = { hello: { world: { lorem: 'ipsum' } } }
 window.choo.copy('hello.world.lorem', object)

--- a/README.md
+++ b/README.md
@@ -43,14 +43,18 @@ Example:
 window.addEventListener('keyup', function (e) {
   // press 'c' to copy current state
   if (e.keyCode === 67) {
-    window.choo.copy(window.choo.state)
+    window.choo.copy()
   }
 })
 
 // also works with nested paths such as:
 var object = { hello: { world: { lorem: 'ipsum' } } }
 window.choo.copy('hello.world.lorem', object)
-// will copy 'ipsum' to keyboard
+// will copy 'ipsum' to clipboard
+
+// and objects:
+window.choo.copy({cool: 'hey'})
+// will copy {'cool': 'hey'} to clipboard
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Get the current state.
 Get an overview of the most recent events.
 
 ### `window.choo.copy`
-Seralize an object into JSON and copy it to the clipboard.
+Serialize an object into JSON and copy it to the clipboard.
 Must be called in response to a user gesture event, like click or keyup.
 
 Example:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var removeItems = require('remove-array-items')
 var onIdle = require('on-idle')
+var stateCopy = require('state-copy')
+var pluck = require('plucker')
 
 var MAX_HISTORY_LENGTH = 150   // How many items we should keep around
 
@@ -21,6 +23,7 @@ function expose () {
     var i = 0
     window.choo._history = history
     window.choo.history = showHistory
+    window.choo.copy = copy
     Object.defineProperty(window.choo, 'log', { get: showHistory })
     Object.defineProperty(window.choo, 'history', { get: showHistory })
 
@@ -39,6 +42,10 @@ function expose () {
     function showHistory () {
       console.table(history)
       return i + ' events recorded, showing the last ' + MAX_HISTORY_LENGTH
+    }
+
+    function copy (state) {
+      stateCopy(typeof state === 'string' ? pluck.apply(this, arguments) : state)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function expose () {
 
     function copy (state) {
       var isStateString = state && typeof state === 'string'
-      var isChooPath = isStateString && state.indexOf('state.') === 0
+      var isChooPath = isStateString && arguments.length === 1 && state.indexOf('state.') === 0
 
       if (!state || typeof state === 'function') state = window.choo.state
       if (isChooPath) [].push.call(arguments, {state: window.choo.state})

--- a/index.js
+++ b/index.js
@@ -45,8 +45,13 @@ function expose () {
     }
 
     function copy (state) {
+      var isStateString = state && typeof state === 'string'
+      var isChooPath = isStateString && state.indexOf('state.') === 0
+
       if (!state || typeof state === 'function') state = window.choo.state
-      stateCopy(typeof state === 'string' ? pluck.apply(this, arguments) : state)
+      if (isChooPath) [].push.call(arguments, {state: window.choo.state})
+
+      stateCopy(isStateString ? pluck.apply(this, arguments) : state)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function expose () {
     }
 
     function copy (state) {
+      if (!state || typeof state === 'function') state = window.choo.state
       stateCopy(typeof state === 'string' ? pluck.apply(this, arguments) : state)
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "on-idle": "^3.1.0",
-    "remove-array-items": "^1.0.0"
+    "plucker": "0.0.0",
+    "remove-array-items": "^1.0.0",
+    "state-copy": "^1.0.1"
   },
   "devDependencies": {
     "dependency-check": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "on-idle": "^3.1.0",
     "plucker": "0.0.0",
     "remove-array-items": "^1.0.0",
-    "state-copy": "^1.0.1"
+    "state-copy": "^1.0.2"
   },
   "devDependencies": {
     "dependency-check": "^2.8.0",


### PR DESCRIPTION
ref: #4 

allows for exposing a `window.choo.copy` method the lets users copy state to clipboard.

example:
```js
window.addEventListener('keyup', function (e) {
  // press 'c' to copy current state to clipboard
  if (e.keyCode === 67) {
    window.choo.copy(window.choo.state)
  }
})
```

Note: it turns out document.execCommand('copy') [only works with user gestured events such as click and keyup](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Interact_with_the_clipboard#Writing_to_the_clipboard).  Thats the reason why the example has an event listener. I had an idea too, it might be useful for there to be a choo-expose-ui that creates a nice button for choo devs to click and get application state in the clipboard.  Would love to get your thoughts!

Cheers!