### PR TITLE
fix choo.log perf impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,6 @@ Log out the Choo state object.
 ❯ choo.state
 ```
 
-### `choo.log`
-Log out the last 150 events that occured in Choo. Useful during debugging to
-quickly figure out which sequences of events were responsible for the current
-state.
-```txt
-❯ choo.log
-```
-
-### `choo.copy([selector])`
-Serialize the current state to JSON and copy it to the clipboard. Can be passed
-a selector (such as `href`) to do a partial copy. Useful if you want to create
-a test based on the current application state.
-```txt
-// Copy all of state.
-❯ choo.copy()
-
-// Copy `state.href`.
-❯ choo.copy('href')
-```
-
 ### `choo.debug`
 Log all state modificiations using
 [object-change-callsite](https://github.com/yoshuawuyts/object-change-callsite/).
@@ -57,6 +37,30 @@ asynchronous stack traces in the devtools.
 
 // Disable debugging
 ❯ choo.debug = false
+```
+
+### `choo.log`
+Log out the last 150 events that occured in Choo. Useful during debugging to
+quickly figure out which sequences of events were responsible for the current
+state.
+```txt
+❯ choo.log
+```
+
+To enable `state` snapshots on each event, call `choo.debug`. Be warned that
+this may severely impact performance – it's recommended to only use this for
+debugging state.
+
+### `choo.copy([selector])`
+Serialize the current state to JSON and copy it to the clipboard. Can be passed
+a selector (such as `href`) to do a partial copy. Useful if you want to create
+a test based on the current application state.
+```txt
+// Copy all of state.
+❯ choo.copy()
+
+// Copy `state.href`.
+❯ choo.copy('href')
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var EventEmitter = require('events').EventEmitter
+
 var debug = require('./lib/debug')
 var copy = require('./lib/copy')
 var log = require('./lib/log')
@@ -6,6 +8,7 @@ module.exports = expose
 
 function expose () {
   return function (state, emitter, app) {
+    var localEmitter = new EventEmitter()
     emitter.on('DOMContentLoaded', function () {
       if (typeof window === 'undefined') return
       window.choo = {}
@@ -18,9 +21,9 @@ function expose () {
         emitter.on(eventName, listener)
       }
 
-      Object.defineProperty(window.choo, 'debug', debug(state, emitter, app))
+      Object.defineProperty(window.choo, 'debug', debug(state, emitter, app, localEmitter))
 
-      window.choo.log = log(state, emitter)
+      window.choo.log = log(state, emitter, app, localEmitter)
       window.choo.copy = copy
     })
   }

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -7,7 +7,7 @@ var disabledMessage = 'Debugging disabled. We hope it was helpful! 🙌'
 
 module.exports = debug
 
-function debug (state, emitter, app) {
+function debug (state, emitter, app, localEmitter) {
   var log = nanologger('choo-devtools')
   var enabled = window.localStorage.logLevel === 'debug'
   if (enabled) log.info(enabledMessage)
@@ -23,6 +23,7 @@ function debug (state, emitter, app) {
   return {
     get: function () {
       window.localStorage.logLevel = 'debug'
+      localEmitter.emit('debug', true)
       enabled = true
       return enabledMessage
     },
@@ -30,6 +31,7 @@ function debug (state, emitter, app) {
       assert.equal(typeof bool, 'boolean', 'choo-devtools.debug: bool should be type boolean')
       window.localStorage.logLevel = bool ? 'debug' : 'info'
       enabled = bool
+      localEmitter.emit('debug', enabled)
       if (enabled) log.info(enabledMessage)
       else log.info(disabledMessage)
     }

--- a/lib/log.js
+++ b/lib/log.js
@@ -6,9 +6,14 @@ var MAX_HISTORY_LENGTH = 150   // How many items we should keep around
 
 module.exports = log
 
-function log (state, emitter) {
+function log (state, emitter, app, localEmitter) {
+  var shouldDebug = window.localStorage.logLevel === 'debug'
   var history = []
   var i = 0
+
+  localEmitter.on('debug', function (bool) {
+    shouldDebug = bool
+  })
 
   window.choo._history = history
   window.choo.history = showHistory
@@ -33,10 +38,12 @@ function log (state, emitter) {
     var events = i === 1 ? 'event' : 'events'
     return `${i} ${events} recorded, showing the last ${MAX_HISTORY_LENGTH}`
   }
-}
 
-function Event (name, data, state) {
-  this.name = name
-  this.data = data
-  this.state = clone(state)
+  function Event (name, data, state) {
+    this.name = name
+    this.data = data
+    this.state = shouldDebug
+      ? clone(state)
+      : 'Enable by calling `choo.debug`.'
+  }
 }


### PR DESCRIPTION
Makes it so `choo.log` no longer records state snapshots out of the box; fixing a performance regression found in https://github.com/hypermodules/hyperamp/issues/237, and referenced in https://github.com/choojs/discuss/issues/2.

@ungoldman could you verify if this fixes the regression? Thanks!

## Screenshot

<img width="821" alt="screen shot 2017-10-08 at 22 41 41" src="https://user-images.githubusercontent.com/2467194/31323790-81ac9248-ac7a-11e7-8926-2056881e34f2.png">
