### PR TITLE
Fix bug in window.choo.log assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function expose () {
 
       Object.defineProperty(window.choo, 'debug', debug(state, emitter, app, localEmitter))
 
-      window.choo.log = log(state, emitter, app, localEmitter)
+      log(state, emitter, app, localEmitter)
       window.choo.copy = copy
       window.choo.routes = Object.keys(getAllRoutes(app.router.router))
 


### PR DESCRIPTION
I kept getting a weird bug with choo-devtools in Beaker (see Screenshot). I debugged and found that the `log` function works on the `window.choo.log` global directly and thus removing the (unneeded, I think) assignment fixed it for me.

![devtools](https://user-images.githubusercontent.com/43627/32454026-3e44ff4e-c31e-11e7-82a6-91a62df4d63a.png)