### PR TITLE
.render and .morph aren't always present

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -42,7 +42,7 @@ function logger (state, emitter) {
   })
 
   hooks.on('render', function (timings) {
-    if (!timings) return logger('info')('render')
+    if (!timings || !timings.render) return logger('info')('render')
     var duration = timings.render.duration.toFixed()
     var msg = 'render'
 
@@ -57,10 +57,11 @@ function logger (state, emitter) {
     if (fps === 60) {
       logger('info')(msg, fps + 'fps', duration + 'ms')
     } else {
-      logger('warn')(msg, fps + 'fps', duration + 'ms', {
-        render: timings.render.duration.toFixed() + 'ms',
-        morph: timings.morph.duration.toFixed() + 'ms'
-      })
+      var times = {
+        render: timings.render.duration.toFixed() + 'ms'
+      }
+      if (timings.morph) times.morph = timings.morph.duration.toFixed() + 'ms'
+      logger('warn')(msg, fps + 'fps', duration + 'ms', times)
     }
   })
 


### PR DESCRIPTION
This fixes data access issues when the `render` and `morph` objects aren't
available during the timing calls.

Why they're missing is a great question (and one I'm looking into now) but this
solves the TypeError that gets thrown for now.