### PR TITLE
wrap routes assignment in app.router conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ function expose () {
 
       log(state, emitter, app, localEmitter)
       window.choo.copy = copy
-      window.choo.routes = Object.keys(getAllRoutes(app.router.router))
+      if (app.router && app.router.router) {
+        window.choo.routes = Object.keys(getAllRoutes(app.router.router))
+      }
 
       storage()
       help()


### PR DESCRIPTION
Hello! 👋 

Currently, an error is thrown when attempting to use `choo-devtools` with [`nanochoo`](https://github.com/heyitsmeuralex/nanochoo).

<p>
<details>
<summary>
<code>Uncaught TypeError: Cannot read property 'router' of undefined</code>
</summary>

```console
/Users/ng/dev/lab/xgl/node_modules/choo-devtools/index.js:40 Uncaught TypeError: Cannot read property 'router' of undefined
    at Function.<anonymous> (/Users/ng/dev/lab/xgl/node_modules/choo-devtools/index.js:40)
    at Nanobus._emit (/Users/ng/dev/lab/xgl/node_modules/nanobus/index.js:160)
    at Nanobus.emit (/Users/ng/dev/lab/xgl/node_modules/nanobus/index.js:26)
    at /Users/ng/dev/lab/xgl/node_modules/nanochoo/lib/browser.js:91
    at documentReady (/Users/ng/dev/lab/xgl/node_modules/nanochoo/lib/browser.js:7)
    at Choo.start (/Users/ng/dev/lab/xgl/node_modules/nanochoo/lib/browser.js:90)
    at HTMLDocument.<anonymous> (/Users/ng/dev/lab/xgl/node_modules/nanochoo/lib/browser.js:110)
```

</details>
</p>


All that needs to be done to allow choo-devtools to be compatible with nanochoo is to wrap assigment of `window.choo.routes` in a conditional check for the existence of `app.router.router`.

This changes no functionality for choo, so hopefully no objections to adding this to the codebase :)