### PR TITLE
Remove ES6 Syntax

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -15,7 +15,7 @@ function debug (state, emitter, app, localEmitter) {
   state = onChange(state, function (attr, value, callsite) {
     if (!enabled) return
     callsite = callsite.split('\n')[1].replace(/^ +/, '')
-    log.info(`state.${attr}`, value, '\n' + callsite)
+    log.info('state.' + attr, value, '\n' + callsite)
   })
 
   app.state = state

--- a/lib/log.js
+++ b/lib/log.js
@@ -41,7 +41,7 @@ function log (state, emitter, app, localEmitter) {
       console.table(history)
     }, 0)
     var events = i === 1 ? 'event' : 'events'
-    var msg = `${i} ${events} recorded, showing the last ${MAX_HISTORY_LENGTH}.`
+    var msg = i + ' ' + events + ' recorded, showing the last ' + MAX_HISTORY_LENGTH + '.'
     if (shouldDebug === false) {
       msg += ' Enable state capture by calling `choo.debug`.'
     } else {

--- a/lib/perf.js
+++ b/lib/perf.js
@@ -112,7 +112,7 @@ Perf.prototype.get = function () {
     return b['Total Time (ms)'] - a['Total Time (ms)']
   })
   console.table(res)
-  return `Showing performance events for '${this.name}'`
+  return "Showing performance events for '" + this.name + "'"
 }
 
 // An entry for the performance timeline.
@@ -128,7 +128,7 @@ function PerfEntry (name, totalTime, median, count) {
 // Get the median from an array of numbers.
 function getMedian (args) {
   if (!args.length) return 0
-  var numbers = args.slice(0).sort((a, b) => a - b)
+  var numbers = args.slice(0).sort(function (a, b) { return a - b })
   var middle = Math.floor(numbers.length / 2)
   var isEven = numbers.length % 2 === 0
   var res = isEven ? (numbers[middle] + numbers[middle - 1]) / 2 : numbers[middle]


### PR DESCRIPTION
Remove ES6 template strings & arrow functions to help with issue #31 

`choojs/object-change-callsite` dependency will also need to be updated because it also still has the same issue (uses ES6 Proxy without a polyfill). I'll be working on a pull request for that next.