### PR TITLE
Update nanologger

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "choo-hooks": "^1.0.0",
     "clone": "^2.1.1",
     "global": "^4.3.2",
-    "nanologger": "^1.3.1",
+    "nanologger": "^2.0.0",
     "nanoscheduler": "^1.0.0",
     "object-change-callsite": "^1.0.2",
     "on-performance": "^1.2.1",


### PR DESCRIPTION
Update to latest nanologger sans `xtend` in preparation for https://github.com/choojs/choo/issues/700