### PR TITLE
Fix logger running in node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter
-var window = require('global/window')
 
 var storage = require('./lib/storage')
 var logger = require('./lib/logger')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "choo-hooks": "^1.0.0",
     "clone": "^2.1.1",
-    "global": "^4.3.2",
     "nanologger": "^2.0.0",
     "nanoscheduler": "^1.0.0",
     "object-change-callsite": "^1.0.2",


### PR DESCRIPTION
This removes the dependency `global/window` which would cause the logger to run in node.