### PR TITLE
Update state-copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "plucker": "0.0.0",
     "prettier-bytes": "^1.0.4",
     "remove-array-items": "^1.0.0",
-    "state-copy": "^1.0.2",
+    "state-copy": "^1.0.5",
     "wayfarer": "^6.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
New version of state-copy is using a different lib for the `copy to clipboard` feature.
Main issue was that state-copy included `copy-text-to-clipboard` from a github fork.
See https://github.com/jekrb/state-copy/pull/3