### PR TITLE
fix(choo.emit): pass all arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ function expose (opts) {
       window.choo = {}
 
       window.choo.state = state
-      window.choo.emit = function (eventName, data) {
-        emitter.emit(eventName, data)
+      window.choo.emit = function () {
+        emitter.emit.apply(emitter, arguments)
       }
       window.choo.on = function (eventName, listener) {
         emitter.on(eventName, listener)


### PR DESCRIPTION
fixes an issue with `choo.emit` where any additional arguments past eventName & data were dropped.

Pairs nicely with https://github.com/choojs/choo-hooks/pull/6

![Screen Shot 2019-10-25 at 1 46 53 PM](https://user-images.githubusercontent.com/427322/67603583-328a6e00-f72e-11e9-9cde-107e732ef1d2.png)
