### PR TITLE
remove use hook

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,10 +29,6 @@ function logger (state, emitter, opts) {
     }
   })
 
-  hooks.on('use', function (count, duration) {
-    logger('debug')('use', { count: count }, duration + 'ms')
-  })
-
   hooks.on('unhandled', function (eventName, data) {
     logger('error')('No listeners for ' + eventName)
   })


### PR DESCRIPTION
Removes a hook that produces an outdated/incorrect debug message on every app start.

Resolves https://github.com/choojs/choo-devtools/issues/38.